### PR TITLE
redis 검색 성능 개선

### DIFF
--- a/src/main/java/com/project/stress_traffic_system/product/service/ProductRedisService.java
+++ b/src/main/java/com/project/stress_traffic_system/product/service/ProductRedisService.java
@@ -291,17 +291,12 @@ public class ProductRedisService {
 
 //        Set<String> keys = productRedisTemplate.keys("product-name" + "*" + keyword + "*");
 
-        ScanOptions options = ScanOptions.scanOptions().match("product-name" + "*" + keyword + "*").build();
+        ScanOptions options = ScanOptions.scanOptions().match("product-name" + "*" + keyword + "*").count(300).build();
         Cursor<byte[]> keys = scanKeys(options);
 
         List<ProductResponseDto> result = new ArrayList<>();
-        while (true) {
-            try{
-                result.add(productRedisTemplate.opsForValue().get(new String(keys.next())));
-            }
-            catch(Exception e) {
-                break;
-            }
+        while (keys.hasNext()) {
+            result.add(productRedisTemplate.opsForValue().get(new String(keys.next())));
         }
 //        for (String key : keys) {
 //            result.add(productRedisTemplate.opsForValue().get(key));


### PR DESCRIPTION
scan할 때 한 번에 불러오는 개수를 증가시켜 검색속도를 개선했습니다.(기존 2배 정도)
scan시 count의 개수와 latency는 반비례 합니다.
(참고사이트)
https://medium.com/@chlee7746/redis-scan-%EB%AA%85%EB%A0%B9%EC%96%B4-%ED%8D%BC%ED%8F%AC%EB%A8%BC%EC%8A%A4-e29e242b8038